### PR TITLE
fixed the event list sidebar growing out of the bounds of the window …

### DIFF
--- a/src/app/sidebar/sidebar.component.css
+++ b/src/app/sidebar/sidebar.component.css
@@ -6,6 +6,7 @@
 #event-list{
     flex: 1;
     overflow-y: scroll;
+    flex-basis: 100px; /* Prevents event list from growing too large for the window size */
 }
 
 .search-header{


### PR DESCRIPTION
…by adding flex-basis to the container

The value doesn't actually matter; I've tried 100-300px and it still works.

see https://css-tricks.com/snippets/css/a-guide-to-flexbox/

I tried it on mobile view, and changed the viewport size around on desktop and it still works. :)