### PR TITLE
somehow prevents vertical stretching of the event detail with flex-basis: 100px

### DIFF
--- a/src/app/event-detail/event-detail.component.css
+++ b/src/app/event-detail/event-detail.component.css
@@ -33,6 +33,7 @@
 	word-break: break-word;
 	overflow-y: scroll;
 	flex: 1;
+  flex-basis: 100px; /* doesn't matter the amount, somehow prevents vertical stretching of the page */
 }
 
 .event-image {


### PR DESCRIPTION
when you click an event in the sidebar in calendar view it used to stretch out the whole page vertically and it was weird

now it doesn't because we added flex-basis: 100px to the .event-body

not sure why it works but it does.

![Screenshot_2019-04-04_12-57-03](https://user-images.githubusercontent.com/20587215/55601081-dde0c080-5713-11e9-9377-e5955d5050ec.png)
