### PR TITLE
removed flex for mobile bc it's prob out of date

### DIFF
--- a/src/app/week/week.component.scss
+++ b/src/app/week/week.component.scss
@@ -212,11 +212,5 @@
     .weekview-header > .long-abbr {
         display: none;
     }
-    /* make day text centered */
-    .weekview-day {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
 }
 /* end mobile css */


### PR DESCRIPTION
I removed flex from weekview's media query

What it looked like before:
<img width="402" alt="Screen Shot 2019-05-08 at 6 37 03 PM" src="https://user-images.githubusercontent.com/22732325/57421416-8de89400-71c0-11e9-8bf1-1fe277702697.png">

What it looks like now:
<img width="402" alt="Screen Shot 2019-05-08 at 6 37 38 PM" src="https://user-images.githubusercontent.com/22732325/57421417-8de89400-71c0-11e9-9a6c-daf573525f7d.png">
