### PR TITLE
Overcrowding Carets Fix Attempt

### DIFF
--- a/src/app/calendar-container/calendar-container.component.html
+++ b/src/app/calendar-container/calendar-container.component.html
@@ -1,24 +1,34 @@
 <div class="calendar">
   <div class="selector">
       <!-- if current route is week -->
-      <div id="week-number" *ngIf="this.router.url.startsWith('/calendar/week')">
+      <div id="week-number" *ngIf="this.router.url.startsWith('/calendar/week'); else emptyBlock">
         <span *ngIf="this.weekNumber">{{this.weekNumber}}</span>
       </div>
+      <ng-template #emptyBlock>
+        <div id="empty-selector-block"></div>
+      </ng-template>
+      <span id="mobile-week-switch" class="navbar-text"  routerLink="week" routerLinkActive="active" (click)="changeDateSpan(0)">Week</span>
       <!-- month and year label -->
-      <div id="calendar-controls">
-        <button id="left-caret" class="custom-btn">
-          <i class="fa fa-caret-left" (click)="changeDateSpan(-1)" aria-hidden="true"></i>
-        </button>
-        <span>{{viewDate}}</span>
-        <button id="right-caret" class="custom-btn">
-          <i class="fa fa-caret-right" (click)="changeDateSpan(1)" aria-hidden="true"></i>
-        </button>
+      <div id="calendar-controls-wrapper">
+        <div id="calendar-controls">
+          <button id="left-caret" class="custom-btn">
+            <i class="fa fa-caret-left" (click)="changeDateSpan(-1)" aria-hidden="true"></i>
+          </button>
+          <span>{{viewDate}}</span>
+          <button id="right-caret" class="custom-btn">
+            <i class="fa fa-caret-right" (click)="changeDateSpan(1)" aria-hidden="true"></i>
+          </button>
+        </div>
+        <div id="mobile-week-number" *ngIf="this.router.url.startsWith('/calendar/week')">
+          <span *ngIf="this.weekNumber">{{this.weekNumber}}</span>
+        </div>
       </div>
       <!-- buttons for changing between week and month view -->
       <div id="month-week-switch">
         <span id="week-switch" class="navbar-text"  routerLink="week" routerLinkActive="active" (click)="changeDateSpan(0)">Week</span>
         <span id="month-switch" class="navbar-text"  routerLink="month" routerLinkActive="active" (click)="changeDateSpan(0)">Month</span>
       </div>
+      <span id="mobile-month-switch" class="navbar-text"  routerLink="month" routerLinkActive="active" (click)="changeDateSpan(0)">Month</span>
     </div>
     <!-- where month and week view appear -->
     <router-outlet class="router-flex"></router-outlet>

--- a/src/app/calendar-container/calendar-container.component.scss
+++ b/src/app/calendar-container/calendar-container.component.scss
@@ -145,6 +145,9 @@ router-outlet.router-flex + * {
 /* mobile css */
 @media screen and (max-width: 768px) {
     /* display short day abbreviations */
+    #calendar-controls-wrapper {
+        width: 150px;
+    }
     #calendar-controls {
         font-size: 20px;
     }

--- a/src/app/calendar-container/calendar-container.component.scss
+++ b/src/app/calendar-container/calendar-container.component.scss
@@ -10,8 +10,12 @@ $selector-padding: 9.7px;
     position: relative;
     font-size: 26px;
     display: flex;
-    justify-content: center;
+    justify-content: space-between;
     padding: $selector-padding;
+}
+
+#empty-selector-block {
+    width: 100px;
 }
 
 :host {
@@ -48,30 +52,38 @@ router-outlet.router-flex + * {
 }
 
 #calendar-controls {
-    width: 300px;
+    font-size: 26px;
 }
 
-#calendar-controls i {
+#calendar-controls-wrapper {
+    width: 200px;
+}
+
+#calendar-controls-wrapper i {
     font-size: 30px;
 }
 
-#calendar-controls span {
+#calendar-controls-wrapper span {
     margin: 0 10px;
 }
 
 #month-week-switch {
     font-size: 0.8rem;
-    position: absolute;
-    right: $selector-padding;
-    top: 8px;
     cursor: pointer;
+    display: flex;
+    margin-left: 5px;
 }
 
 #week-number {
-  position: absolute;
-  left: 30px;
-  top: 10px;
   font-size: 20px;
+  width: 100px;
+}
+
+#mobile-week-number {
+    display: none;
+    z-index: 1000;
+    font-size: 10px;
+    text-align: center;
 }
 
 #month-switch {
@@ -100,4 +112,61 @@ router-outlet.router-flex + * {
     padding: 4px 10px;
     font-size: 18px;
     margin: 0;
+}
+
+#mobile-month-switch {
+    display: none;
+    border-radius: 4px;
+    border: $default_border_width solid $default_border_color;
+    padding: 8px 10px;
+    font-size: 18px;
+    margin: 0;
+}
+
+#mobile-month-switch.active {
+    background: #656565;
+    color: #fff;
+}
+
+#mobile-week-switch.active {
+    background: #656565;
+    color: #fff;
+}
+
+#mobile-week-switch {
+    display: none;
+    border-radius: 4px;
+    border: $default_border_width solid $default_border_color;
+    padding: 8px 10px;
+    font-size: 18px;
+    margin: 0;
+}
+
+/* mobile css */
+@media screen and (max-width: 768px) {
+    /* display short day abbreviations */
+    #calendar-controls {
+        font-size: 20px;
+    }
+    #week-number {
+        display: none;
+    }
+    #month-week-switch {
+        display: none;
+    }
+    #empty-selector-block {
+        display: none;
+    }
+    #mobile-week-switch {
+        display: flex;
+        align-items: center;
+    }
+    
+    #mobile-month-switch {
+        display: flex;
+        align-items: center;
+    }
+    #mobile-week-number {
+        display: block;
+    }
 }

--- a/src/app/calendar-container/calendar-container.component.ts
+++ b/src/app/calendar-container/calendar-container.component.ts
@@ -52,7 +52,7 @@ export class CalendarContainerComponent implements OnInit {
   }
 
   viewDateChange(set : Date) {
-    this.viewDate = set.toLocaleDateString("en-US", {month: 'long', year: 'numeric'});
+    this.viewDate = set.toLocaleDateString("en-US", {month: 'short', year: 'numeric'});
   }
 
   changeDateSpan(delta: number) : void{

--- a/src/app/event-detail/event-detail.component.scss
+++ b/src/app/event-detail/event-detail.component.scss
@@ -29,6 +29,7 @@
 }
 
 .event-body {
+	background: #ffffff;
 	display: block;
 	z-index: 500;
 	padding: 40px;

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -45,8 +45,6 @@ export class NavbarComponent implements OnInit {
       this.currentDate = today.getDate();
     }
 
-    isCollapsed: boolean = true;
-
     emitChangeView(newView: string): void {
       this.changeView.emit(newView);
       let d = new Date();
@@ -70,25 +68,6 @@ export class NavbarComponent implements OnInit {
     toggleTagCollapse(): void {
       this.isFilterCollapsed = !this.isFilterCollapsed;
       this.isCollapsed = true;
-    }
-
-    toggleViews(): void {
-        if (!this._calendarService.isMapView()) {
-            this.emitChangeView('map');
-            this.isMapSelected = true;
-            this._router.navigateByUrl('/map(sidebar:list)');
-        }
-        else {
-            this.isMapSelected = false;
-            if (this._calendarService.retrieveLastView() == 'week'){
-                this.emitChangeView('week')
-                this._router.navigateByUrl('/calendar/week(sidebar:list)');
-            }
-            else {
-                this.emitChangeView('month')
-                this._router.navigateByUrl('/calendar/month(sidebar:list)');
-            }
-        }
     }
 
     getTemperature(): void {


### PR DESCRIPTION
I went with Ryan's suggestion: I placed the week number below the month in mobile view. 

- Month View Desktop
  <img width="754" alt="Screen Shot 2019-05-12 at 12 37 26 AM" src="https://user-images.githubusercontent.com/22732325/57579230-247db500-744e-11e9-8441-0e487da716b4.png">

- Week View Desktop
  <img width="750" alt="Screen Shot 2019-05-12 at 12 36 53 AM" src="https://user-images.githubusercontent.com/22732325/57579232-28a9d280-744e-11e9-951f-20941a15c60e.png">

- Month View Mobile 
  <img width="404" alt="Screen Shot 2019-05-12 at 12 37 13 AM" src="https://user-images.githubusercontent.com/22732325/57579235-2d6e8680-744e-11e9-92fe-9cd41260251f.png">

- Week View Mobile
  <img width="399" alt="Screen Shot 2019-05-12 at 12 37 00 AM" src="https://user-images.githubusercontent.com/22732325/57579234-2cd5f000-744e-11e9-8d21-58777fecdac0.png">
